### PR TITLE
Add example-network.json from network-lab to tests

### DIFF
--- a/tests/example-network.json
+++ b/tests/example-network.json
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "1": {
+        "ip": "1.0.0.1"
+    },
+    "2": {
+        "ip": "1.0.0.2"
+    },
+    "3": {
+        "ip": "1.0.0.3"
+    }
+  },
+  "edges": [
+    {
+      "nodes": ["1", "2"],
+      "->": "delay 10ms 20ms distribution normal",
+      "<-": "delay 500ms 20ms distribution normal"
+    },
+    {
+      "nodes": ["2", "3"],
+      "->": "delay 10ms 20ms distribution normal",
+      "<-": "delay 500ms 20ms distribution normal"
+    }
+  ]
+}


### PR DESCRIPTION
I **always** find myself looking for this file and end up getting it from `sudomesh`. Since `sudomesh/network-lab` doesn't have a license, I'll mention this PR in an issue in `network-lab`.