### PR TITLE
`tests/` envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PREFIX = /usr/local
 MANDIR = $(PREFIX)/share/man
 
-CDEBUGFLAGS = -Os -g -Wall
+CDEBUGFLAGS = -O0 -g -Wall $(DEFINES) $(EXTRA_DEFINES)
 
 DEFINES = $(PLATFORM_DEFINES)
 
-CFLAGS = $(CDEBUGFLAGS) $(DEFINES) $(EXTRA_DEFINES)
+CFLAGS = -Os -Wall $(DEFINES) $(EXTRA_DEFINES)
 
 LDLIBS = -lrt
 
@@ -19,6 +19,9 @@ OBJS = babeld.o net.o kernel.o util.o interface.o source.o neighbour.o \
 
 babeld: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o babeld $(OBJS) $(LDLIBS)
+
+debug:
+	$(MAKE) "CFLAGS=$(CDEBUGFLAGS)" babeld
 
 babeld.o: babeld.c version.h
 

--- a/tests/multihop-basic.sh
+++ b/tests/multihop-basic.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eux
 
-export LABPATH=./
-export BABELPATH=../babeld
+export LABPATH=${LABPATH:=./network-lab.sh}
+export BABELPATH=${BABELPATH:=../babeld}
 
 # This is a basic integration test for the Althea fork of Babeld, it focuses on
 # validating that instances actually come up and communicate
@@ -40,7 +40,7 @@ cleanup()
 
 cleanup
 
- source $LABPATH/network-lab.sh << EOF
+ source $LABPATH << EOF
 {
   "nodes": {
     "1": { "ip": "1.0.0.1" },
@@ -67,15 +67,15 @@ EOF
 
 ip netns exec netlab-1 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-1 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-1 ../babeld -I babeld-n1.pid -d 1 -L babeld-n1.log -P 5 -w veth-1-2 &
+ip netns exec netlab-1 $BABELPATH -I babeld-n1.pid -d 1 -L babeld-n1.log -P 5 -w veth-1-2 &
 
 ip netns exec netlab-2 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-2 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-2 ../babeld -I babeld-n2.pid -d 1 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 &
+ip netns exec netlab-2 $BABELPATH -I babeld-n2.pid -d 1 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 &
 
 ip netns exec netlab-3 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-3 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-3 ../babeld -I babeld-n3.pid -d 1 -L babeld-n3.log -P 1 -w veth-3-2&
+ip netns exec netlab-3 $BABELPATH -I babeld-n3.pid -d 1 -L babeld-n3.log -P 1 -w veth-3-2&
 
 sleep 15
 fail_string "malformed" "babeld-n1.log"

--- a/tests/multihop-basic.sh
+++ b/tests/multihop-basic.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eux
 
-export LABPATH=${LABPATH:=./network-lab.sh}
-export BABELPATH=${BABELPATH:=../babeld}
+BABELPATH=${BABELPATH:=../babeld}
+LABPATH=${LABPATH:=./network-lab.sh}
 
 # This is a basic integration test for the Althea fork of Babeld, it focuses on
 # validating that instances actually come up and communicate

--- a/tests/multihop-hand.sh
+++ b/tests/multihop-hand.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -eux
 
-export LABPATH=./
-export BABELPATH=../babeld
+GDBPATH=${GDBPATH:=gdb}
+
+export LABPATH=${LABPATH:=./network-lab.sh}
+export BABELPATH=${BABELPATH:=../babeld}
 
 # This is a basic integration test for the Althea fork of Babeld, it focuses on
 # validating that instances actually come up and communicate
@@ -41,7 +43,7 @@ cleanup()
 
 cleanup
 
- source $LABPATH/network-lab.sh << EOF
+ source $LABPATH << EOF
 {
   "nodes": {
     "1": { "ip": "1.0.0.1" },
@@ -89,16 +91,16 @@ EOF
 
 ip netns exec netlab-1 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-1 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-1 ../babeld -I babeld-n1.pid -d 1 -L babeld-n1.log -P 5 -w veth-1-2 veth-1-4 &
+ip netns exec netlab-1 $BABELPATH -I babeld-n1.pid -d 1 -L babeld-n1.log -P 5 -w veth-1-2 veth-1-4 &
 
 ip netns exec netlab-2 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-2 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-2 ../babeld -I babeld-n2.pid -d 1 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 &
+ip netns exec netlab-2 $BABELPATH -I babeld-n2.pid -d 1 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 &
 
 ip netns exec netlab-3 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-3 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-3 ../babeld -I babeld-n3.pid -d 1 -L babeld-n3.log -P 1 -w veth-3-2 veth-3-4 &
+ip netns exec netlab-3 $BABELPATH -I babeld-n3.pid -d 1 -L babeld-n3.log -P 1 -w veth-3-2 veth-3-4 &
 
 ip netns exec netlab-4 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-4 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-4 gdb --args ../babeld -I babeld-n4.pid -d 1 -L babeld-n4.log -P 15 -w veth-4-1 veth-4-3
+ip netns exec netlab-4 $GDBPATH --args $BABELPATH -I babeld-n4.pid -d 1 -L babeld-n4.log -P 15 -w veth-4-1 veth-4-3

--- a/tests/multihop-hand.sh
+++ b/tests/multihop-hand.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -eux
 
+BABELPATH=${BABELPATH:=../babeld}
+CONFIGPORT=${CONFIGPORT:=6126}
 GDBPATH=${GDBPATH:=gdb}
-
-export LABPATH=${LABPATH:=./network-lab.sh}
-export BABELPATH=${BABELPATH:=../babeld}
+LABPATH=${LABPATH:=./network-lab.sh}
 
 # This is a basic integration test for the Althea fork of Babeld, it focuses on
 # validating that instances actually come up and communicate
@@ -91,16 +91,20 @@ EOF
 
 ip netns exec netlab-1 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-1 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-1 $BABELPATH -I babeld-n1.pid -d 1 -L babeld-n1.log -P 5 -w veth-1-2 veth-1-4 &
+ip netns exec netlab-1 ip link set up dev lo
+ip netns exec netlab-1 $BABELPATH -G $CONFIGPORT -I babeld-n1.pid -d 1 -L babeld-n1.log -P 5 -w veth-1-2 veth-1-4 &
 
 ip netns exec netlab-2 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-2 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-2 $BABELPATH -I babeld-n2.pid -d 1 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 &
+ip netns exec netlab-2 ip link set up dev lo
+ip netns exec netlab-2 $BABELPATH -G $CONFIGPORT -I babeld-n2.pid -d 1 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 &
 
 ip netns exec netlab-3 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-3 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-3 $BABELPATH -I babeld-n3.pid -d 1 -L babeld-n3.log -P 1 -w veth-3-2 veth-3-4 &
+ip netns exec netlab-3 ip link set up dev lo
+ip netns exec netlab-3 $BABELPATH -G $CONFIGPORT -I babeld-n3.pid -d 1 -L babeld-n3.log -P 1 -w veth-3-2 veth-3-4 &
 
 ip netns exec netlab-4 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-4 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-4 $GDBPATH --args $BABELPATH -I babeld-n4.pid -d 1 -L babeld-n4.log -P 15 -w veth-4-1 veth-4-3
+ip netns exec netlab-4 ip link set up dev lo
+ip netns exec netlab-4 $GDBPATH --args $BABELPATH -G $CONFIGPORT -I babeld-n4.pid -d 1 -L babeld-n4.log -P 15 -w veth-4-1 veth-4-3

--- a/tests/multihop-rtt.sh
+++ b/tests/multihop-rtt.sh
@@ -1,8 +1,8 @@
 #/usr/bin/env bash
 set -eux
 
-export LABPATH=./
-export BABELPATH=../babeld
+export LABPATH=${LABPATH:=./network-lab.sh}
+export BABELPATH=${BABELPATH:=../babeld}
 
 # This is a basic integration test for the Althea fork of Babeld, it focuses on
 # validating that instances actually come up and communicate
@@ -40,7 +40,7 @@ cleanup()
 
 cleanup
 
- source $LABPATH/network-lab.sh << EOF
+ source $LABPATH << EOF
 {
   "nodes": {
     "1": { "ip": "1.0.0.1" },
@@ -67,12 +67,12 @@ EOF
 
 ip netns exec netlab-1 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-1 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-1 ../babeld -I babeld-n1.pid -d 3 -L babeld-n1.log -P 5 -w veth-1-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
+ip netns exec netlab-1 $BABELPATH -I babeld-n1.pid -d 3 -L babeld-n1.log -P 5 -w veth-1-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
 
 ip netns exec netlab-2 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-2 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-2 ../babeld -I babeld-n2.pid -d 3 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
+ip netns exec netlab-2 $BABELPATH -I babeld-n2.pid -d 3 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
 
 ip netns exec netlab-3 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-3 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-3 ../babeld -I babeld-n3.pid -d 3 -P 1 -w veth-3-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true'
+ip netns exec netlab-3 $BABELPATH -I babeld-n3.pid -d 3 -P 1 -w veth-3-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true'

--- a/tests/multihop-rtt.sh
+++ b/tests/multihop-rtt.sh
@@ -1,8 +1,9 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 set -eux
 
-export LABPATH=${LABPATH:=./network-lab.sh}
-export BABELPATH=${BABELPATH:=../babeld}
+BABELPATH=${BABELPATH:=../babeld}
+CONFIGPORT=${CONFIGPORT:=6126}
+LABPATH=${LABPATH:=./network-lab.sh}
 
 # This is a basic integration test for the Althea fork of Babeld, it focuses on
 # validating that instances actually come up and communicate
@@ -67,12 +68,15 @@ EOF
 
 ip netns exec netlab-1 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-1 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-1 $BABELPATH -I babeld-n1.pid -d 3 -L babeld-n1.log -P 5 -w veth-1-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
+ip netns exec netlab-1 ip link set up dev lo
+ip netns exec netlab-1 $BABELPATH -G $CONFIGPORT -I babeld-n1.pid -d 3 -L babeld-n1.log -P 5 -w veth-1-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
 
 ip netns exec netlab-2 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-2 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-2 $BABELPATH -I babeld-n2.pid -d 3 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
+ip netns exec netlab-2 ip link set up dev lo
+ip netns exec netlab-2 $BABELPATH -G $CONFIGPORT -I babeld-n2.pid -d 3 -L babeld-n2.log -P 10 -w veth-2-1 -w veth-2-3 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true' &
 
 ip netns exec netlab-3 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-3 sysctl -w net.ipv6.conf.all.forwarding=1
-ip netns exec netlab-3 $BABELPATH -I babeld-n3.pid -d 3 -P 1 -w veth-3-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true'
+ip netns exec netlab-3 ip link set up dev lo
+ip netns exec netlab-3 $BABELPATH -G $CONFIGPORT -I babeld-n3.pid -d 3 -P 1 -w veth-3-2 -C 'default max-rtt-penalty 100' -C 'default enable-timestamps true'


### PR DESCRIPTION
I've added a `GDBPATH` env for specifying which GDB executable to use in `multihop-hand` and also noticed an unused `BABELPATH` variable; made all the envs overrideable, e.g.:
```sh
$ sudo GDBPATH=cgdb ./multihop-basic.sh # Someone might want to use a GDB wrapper
$ sudo BABELPATH=some_other_babeld_exec ./multihop-basic.sh # Someone might want to test a different babeld exec for some elusive bug/performance drop/whatever without running around different repos
$ sudo LABPATH=~/other_lab_script.sh ./multihop-basic.sh # ...same goes for network-lab.sh scripts
```