### PR TITLE
Fix remaining full-path RTT issues

### DIFF
--- a/babeld.c
+++ b/babeld.c
@@ -1091,8 +1091,8 @@ dump_route(FILE *out, struct babel_route *route)
         snprintf(channels + j, 100 - j, ")");
     }
 
-    fprintf(out, "%s%s%s metric %d (%d) price %d refmetric %d rtt %s id %s "
-            "seqno %d%s age %d via %s neigh %s%s%s%s\n",
+    fprintf(out, "%s%s%s metric %d (%d) price %d refmetric %d full-path-rtt %s "
+            "id %s seqno %d%s age %d via %s neigh %s%s%s%s\n",
             format_prefix(route->src->prefix, route->src->plen),
             route->src->src_plen > 0 ? " from " : "",
             route->src->src_plen > 0 ?

--- a/message.c
+++ b/message.c
@@ -169,9 +169,9 @@ parse_update_subtlv(struct interface *ifp, int metric,
             memcpy(channels, a + i + 2, MIN(len, *channels_len_return));
             channels_len = MIN(len, *channels_len_return);
         } else if(type == SUBTLV_PATH_RTT) {
-            memcpy(timestamp, a + i + 2, 4);
+            DO_NTOHL(*timestamp, a + i + 2);
             have_timestamp = 1;
-            printf("Hey look at me I've got a path rtt subtlv with value %s\n", format_thousands(*timestamp));
+            debugf("Hey look at me I've got a path rtt subtlv with value %s\n", format_thousands(*timestamp));
         } else {
             debugf("Received unknown update sub-TLV %d.\n", type);
         }
@@ -570,9 +570,15 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             parse_update_subtlv(ifp, metric, message + parsed_len,
                                 len - parsed_len, channels, &channels_len,
                                 &have_rtt_return, &path_rtt);
+
             if(have_rtt_return && neigh->rtt) {
+                // We captured a full path rtt and have a neigh rtt to attach
                 path_rtt += neigh->rtt;
+            } else {
+                // No full path rtt for this source through this neigh
+                path_rtt = 0;
             }
+
             //TODO update route needs to take timestamps into account
             update_route(router_id, prefix, plen, src_prefix, src_plen, seqno,
                          metric, interval, price, neigh, nh,
@@ -709,9 +715,15 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             parse_update_subtlv(ifp, metric, message + parsed_len,
                                 len - parsed_len, channels, &channels_len,
                                 &have_rtt_return, &path_rtt);
+
             if(have_rtt_return && neigh->rtt) {
+                // We captured a full path rtt and have a neigh rtt to attach
                 path_rtt += neigh->rtt;
+            } else {
+                // No full path rtt for this source through this neigh
+                path_rtt = 0;
             }
+
             //TODO update route needs to take timestamps into account
             update_route(router_id, prefix, plen, src_prefix, src_plen, seqno,
                          metric, interval, price, neigh, nh,

--- a/route.c
+++ b/route.c
@@ -999,9 +999,7 @@ update_route(const unsigned char *id,
         local_notify_route(route, LOCAL_ADD);
         consider_route(route);
     }
-    if(full_path_rtt > 0) {
-        route->full_path_rtt = full_path_rtt;
-    }
+    route->full_path_rtt = full_path_rtt;
     return route;
 }
 


### PR DESCRIPTION
* babeld.c: rename "rtt" to "full-path-rtt" to avoid confusion with
neighbor RTTs
* message.c: add a missing DO_NTOHL to the timestamp parsing code;
default absent full-path RTT's to 0
* route.c: remove an enclosing if statement from route full-path RTT
assignment

The above changes eliminate two sources of garbage full-path RTT values:
* Parsing the full-path RTT sub-TLV without converting from network byte
order
* Not defaulting to 0 full-path RTT value when full-path RTT calculation
is not possible