### PR TITLE
Logarithm-based price metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DEFINES = $(PLATFORM_DEFINES)
 
 CFLAGS = -Os -Wall $(DEFINES) $(EXTRA_DEFINES)
 
-LDLIBS = -lrt
+LDLIBS = -lrt -lm
 
 SRCS = babeld.c net.c kernel.c util.c interface.c source.c neighbour.c \
        route.c xroute.c message.c resend.c configuration.c local.c \

--- a/babeld.c
+++ b/babeld.c
@@ -105,9 +105,10 @@ uint32_t fee = 0;
 
 /**
  * A multiplier to indicate how much the user values quality vs. price metrics;
- * higher value means quality is valued more
+ * higher value means quality is valued more; Value is interpreted as 1000x of
+ * the target value, which makes the default below equal to 1.9
  */
-uint16_t quality_multiplier = 1;
+uint32_t metric_factor = 1900;
 
 static int
 kernel_route_notify(struct kernel_route *route, void *closure)
@@ -182,7 +183,7 @@ main(int argc, char **argv)
 
     while(1) {
         opt = getopt(argc, argv,
-                     "m:p:F:h:H:i:k:A:srS:d:g:G:lwz:M:a:t:T:c:C:DL:I:V");
+                     "m:p:F:h:H:i:k:A:srS:d:g:G:lwz:M:q:t:T:c:C:DL:I:V");
         if(opt < 0)
             break;
 
@@ -303,19 +304,19 @@ main(int argc, char **argv)
             fee = a;
             break;
         }
-        case 'a': {
+        case 'q': {
             char *endptr = optarg;
-            unsigned long a = strtoul(optarg, &endptr, 0);
+            unsigned long factor = strtoul(optarg, &endptr, 0);
             errno = 0;
 
             // Display help if strtoul() fails or the value won't fit
-            if(a > UINT16_MAX || endptr == optarg || errno) {
-                fprintf(stderr, "Couldn't parse the quality multiplier: %s\n",
+            if(factor > UINT32_MAX || endptr == optarg || errno) {
+                fprintf(stderr, "Couldn't parse the metric factor: %s\n",
                         optarg);
                 goto usage;
             }
 
-            quality_multiplier = a;
+            metric_factor = factor;
             break;
         }
         case 't':
@@ -906,7 +907,7 @@ main(int argc, char **argv)
             "               "
             "[-d level] [-D] [-L logfile] [-I pidfile]\n"
             "               "
-            "[-F fee] [-a multiplier]\n"
+            "[-F fee] [-q multiplier]\n"
             "               "
             "interface...\n",
             BABELD_VERSION);

--- a/babeld.h
+++ b/babeld.h
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#define INFINITY ((unsigned short)(~0))
+#define BABEL_INFINITY ((unsigned short)(~0))
 
 #ifndef RTPROT_BABEL
 #define RTPROT_BABEL 42
@@ -109,7 +109,7 @@ extern int kernel_socket;
 extern int max_request_hopcount;
 
 extern uint32_t fee;
-extern uint16_t quality_multiplier;
+extern uint32_t metric_factor;
 
 void schedule_neighbours_check(int msecs, int override);
 void schedule_interfaces_check(int msecs, int override);

--- a/configuration.c
+++ b/configuration.c
@@ -465,12 +465,12 @@ parse_filter(int c, gnc_t gnc, void *closure, struct filter **filter_return)
         } else if(strcmp(token, "allow") == 0) {
             filter->action.add_metric = 0;
         } else if(strcmp(token, "deny") == 0) {
-            filter->action.add_metric = INFINITY;
+            filter->action.add_metric = BABEL_INFINITY;
         } else if(strcmp(token, "metric") == 0) {
             int metric;
             c = getint(c, &metric, gnc, closure);
             if(c < -1) goto error;
-            if(metric <= 0 || metric > INFINITY)
+            if(metric <= 0 || metric > BABEL_INFINITY)
                 goto error;
             filter->action.add_metric = metric;
         } else if(strcmp(token, "src-prefix") == 0) {
@@ -487,7 +487,7 @@ parse_filter(int c, gnc_t gnc, void *closure, struct filter **filter_return)
             int table;
             c = getint(c, &table, gnc, closure);
             if(c < -1) goto error;
-            if(table <= 0 || table > INFINITY)
+            if(table <= 0 || table > BABEL_INFINITY)
                 goto error;
             filter->action.table = table;
         } else {
@@ -801,7 +801,8 @@ parse_option(int c, gnc_t gnc, void *closure, char *token)
            strcmp(token, "diversity") != 0 &&
            strcmp(token, "diversity-factor") != 0 &&
            strcmp(token, "smoothing-half-life") != 0 &&
-           strcmp(token, "fee") != 0)
+           strcmp(token, "fee") != 0 &&
+           strcmp(token, "metric-factor") != 0)
         goto error;
     }
 
@@ -935,12 +936,12 @@ parse_option(int c, gnc_t gnc, void *closure, char *token)
         fee = f;
         check_xroutes(1);
 
-    } else if (strcmp(token, "quality-multiplier") == 0) {
+    } else if (strcmp(token, "metric-factor") == 0) {
         uint32_t f = 0;
         c = getuint32_t(c, &f, gnc, closure);
-        if(c < -1 || f > UINT16_MAX)
+        if(c < -1 || f > UINT32_MAX)
             goto error;
-        quality_multiplier = f;
+        metric_factor = f;
     } else if(strcmp(token, "smoothing-half-life") == 0) {
         int h;
         c = getint(c, &h, gnc, closure);
@@ -1349,7 +1350,7 @@ redistribute_filter(const unsigned char *prefix, unsigned short plen,
     res = do_filter(redistribute_filters, NULL, prefix, plen,
                     src_prefix, src_plen, NULL, ifindex, proto, result);
     if(res < 0)
-        res = INFINITY;
+        res = BABEL_INFINITY;
     return res;
 }
 
@@ -1362,7 +1363,7 @@ install_filter(const unsigned char *prefix, unsigned short plen,
     res = do_filter(install_filters, NULL, prefix, plen,
                     src_prefix, src_plen, NULL, 0, 0, result);
     if(res < 0)
-        res = INFINITY;
+        res = BABEL_INFINITY;
     return res;
 }
 

--- a/disambiguation.c
+++ b/disambiguation.c
@@ -426,7 +426,7 @@ kchange_route_metric(const struct babel_route *route,
                      unsigned refmetric, unsigned cost, unsigned add)
 {
     int old_metric = metric_to_kernel(route_metric(route));
-    int new_metric = metric_to_kernel(MIN(refmetric + cost + add, INFINITY));
+    int new_metric = metric_to_kernel(MIN(refmetric + cost + add, BABEL_INFINITY));
     int rc;
     struct babel_route *rt1 = NULL;
     struct route_stream *stream = NULL;

--- a/message.c
+++ b/message.c
@@ -1307,10 +1307,10 @@ really_send_update(struct interface *ifp,
 
     add_metric = output_filter(id, prefix, plen, src_prefix,
                                src_plen, ifp->ifindex);
-    if(add_metric >= INFINITY)
+    if(add_metric >= BABEL_INFINITY)
         return;
 
-    metric = MIN(metric + add_metric, INFINITY);
+    metric = MIN(metric + add_metric, BABEL_INFINITY);
     /* Worst case */
     ensure_space(ifp, 20 + 12 + 28 + 18 + fp_rtt_size);
 
@@ -1540,7 +1540,7 @@ flushupdates(struct interface *ifp)
                     route_metric(route) :
                     route_metric_noninterfering(route);
 
-                if(metric < INFINITY)
+                if(metric < BABEL_INFINITY)
                     satisfy_request(route->src->prefix, route->src->plen,
                                     route->src->src_prefix,
                                     route->src->src_plen,
@@ -1583,7 +1583,7 @@ flushupdates(struct interface *ifp)
                after an xroute has been retracted, so send a retraction. */
                 really_send_update(ifp, myid, b[i].prefix, b[i].plen,
                                    b[i].src_prefix, b[i].src_plen,
-                                   myseqno, INFINITY, INFINITY ,NULL, -1, 0, 0);
+                                   myseqno, BABEL_INFINITY, BABEL_INFINITY ,NULL, -1, 0, 0);
             }
         }
         schedule_flush_now(ifp);
@@ -1663,7 +1663,7 @@ send_update(struct interface *ifp, int urgent,
             /* Since flushupdates only deals with non-wildcard interfaces, we
                need to do this now. */
             route = find_installed_route(prefix, plen, src_prefix, src_plen);
-            if(route && route_metric(route) < INFINITY)
+            if(route && route_metric(route) < BABEL_INFINITY)
                 satisfy_request(prefix, plen, src_prefix, src_plen,
                                 route->src->seqno, route->src->id, NULL);
         }
@@ -2247,7 +2247,7 @@ handle_request(struct neighbour *neigh, const unsigned char *prefix,
         return;
 
     /* Let's try to forward this request. */
-    if(route && route_metric(route) < INFINITY)
+    if(route && route_metric(route) < BABEL_INFINITY)
         successor = route->neigh;
 
     if(!successor || successor == neigh) {
@@ -2257,7 +2257,7 @@ handle_request(struct neighbour *neigh, const unsigned char *prefix,
 
         other_route = find_best_route(prefix, plen, src_prefix, src_plen,
                                       0, neigh);
-        if(other_route && route_metric(other_route) < INFINITY)
+        if(other_route && route_metric(other_route) < BABEL_INFINITY)
             successor = other_route->neigh;
     }
 

--- a/neighbour.c
+++ b/neighbour.c
@@ -92,7 +92,7 @@ find_neighbour(const unsigned char *address, struct interface *ifp)
 
     neigh->hello.seqno = neigh->uhello.seqno = -1;
     memcpy(neigh->address, address, 16);
-    neigh->txcost = INFINITY;
+    neigh->txcost = BABEL_INFINITY;
     neigh->ihu_time = now;
     neigh->hello.time = neigh->uhello.time = zero;
     neigh->hello_rtt_receive_time = zero;
@@ -203,7 +203,7 @@ reset_txcost(struct neighbour *neigh)
     if(delay >= 180000 || (neigh->hello.reach & 0xFFF0) == 0 ||
        (neigh->ihu_interval > 0 &&
         delay >= neigh->ihu_interval * 10 * 10)) {
-        neigh->txcost = INFINITY;
+        neigh->txcost = BABEL_INFINITY;
         neigh->ihu_time = now;
         return 1;
     }
@@ -284,7 +284,7 @@ neighbour_rxcost(struct neighbour *neigh)
 
     if(((reach & 0xFFF0) == 0 || delay >= 180000) &&
        ((ureach & 0xFFF0) == 0 || udelay >= 180000)) {
-        return INFINITY;
+        return BABEL_INFINITY;
     } else if((neigh->ifp->flags & IF_LQ)) {
         int sreach =
             ((reach & 0x8000) >> 2) +
@@ -295,12 +295,12 @@ neighbour_rxcost(struct neighbour *neigh)
         /* cost >= interface->cost */
         if(delay >= 40000)
             cost = (cost * (delay - 20000) + 10000) / 20000;
-        return MIN(cost, INFINITY);
+        return MIN(cost, BABEL_INFINITY);
     } else {
         if(two_three(reach) || two_three(ureach))
             return neigh->ifp->cost;
         else
-            return INFINITY;
+            return BABEL_INFINITY;
     }
 }
 
@@ -333,16 +333,16 @@ neighbour_cost(struct neighbour *neigh)
     unsigned a, b, cost;
 
     if(!if_up(neigh->ifp))
-        return INFINITY;
+        return BABEL_INFINITY;
 
     a = neighbour_txcost(neigh);
 
-    if(a >= INFINITY)
-        return INFINITY;
+    if(a >= BABEL_INFINITY)
+        return BABEL_INFINITY;
 
     b = neighbour_rxcost(neigh);
-    if(b >= INFINITY)
-        return INFINITY;
+    if(b >= BABEL_INFINITY)
+        return BABEL_INFINITY;
 
     if(!(neigh->ifp->flags & IF_LQ) || (a < 256 && b < 256)) {
         cost = a;
@@ -359,7 +359,7 @@ neighbour_cost(struct neighbour *neigh)
 
     cost += neighbour_rttcost(neigh);
 
-    return MIN(cost, INFINITY);
+    return MIN(cost, BABEL_INFINITY);
 }
 
 int

--- a/resend.c
+++ b/resend.c
@@ -98,10 +98,10 @@ record_resend(int kind, const unsigned char *prefix, unsigned char plen,
     if((kind == RESEND_REQUEST &&
         input_filter(NULL, prefix, plen, src_prefix, src_plen, NULL,
                      ifindex) >=
-        INFINITY) ||
+        BABEL_INFINITY) ||
        (kind == RESEND_UPDATE &&
         output_filter(NULL, prefix, plen, src_prefix, src_plen, ifindex) >=
-        INFINITY))
+        BABEL_INFINITY))
         return 0;
 
     if(delay >= 0xFFFF)

--- a/route.c
+++ b/route.c
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include <errno.h>
 #include <assert.h>
 #include <sys/time.h>
+#include <math.h>
 
 #include "babeld.h"
 #include "util.h"
@@ -434,7 +435,7 @@ route_stream_done(struct route_stream *stream)
 int
 metric_to_kernel(int metric)
 {
-        if(metric >= INFINITY) {
+        if(metric >= BABEL_INFINITY) {
                 return KERNEL_INFINITY;
         } else if(reflect_kernel_metric) {
                 int r = kernel_metric + metric;
@@ -547,7 +548,7 @@ change_route_metric(struct babel_route *route,
                     unsigned refmetric, unsigned cost, unsigned add)
 {
     int old, new;
-    int newmetric = MIN(refmetric + cost + add, INFINITY);
+    int newmetric = MIN(refmetric + cost + add, BABEL_INFINITY);
 
     old = metric_to_kernel(route_metric(route));
     new = metric_to_kernel(newmetric);
@@ -579,7 +580,7 @@ retract_route(struct babel_route *route)
 {
     /* We cannot simply remove the route from the kernel, as that might
        cause a routing loop -- see RFC 6126 Sections 2.8 and 3.5.5. */
-    change_route_metric(route, INFINITY, INFINITY, 0);
+    change_route_metric(route, BABEL_INFINITY, BABEL_INFINITY, 0);
 }
 
 int
@@ -650,7 +651,7 @@ update_feasible(struct source *src,
         /* Never mind what is probably stale data */
         return 1;
 
-    if(refmetric >= INFINITY)
+    if(refmetric >= BABEL_INFINITY)
         /* Retractions are always feasible */
         return 1;
 
@@ -686,7 +687,7 @@ route_smoothed_metric(struct babel_route *route)
     int metric = route_metric(route);
 
     if(smoothing_half_life <= 0 ||                 /* no smoothing */
-       metric >= INFINITY ||                       /* route retracted */
+       metric >= BABEL_INFINITY ||                       /* route retracted */
        route->smoothed_metric_time > now.tv_sec || /* clock stepped */
        route->smoothed_metric == metric) {         /* already converged */
         route->smoothed_metric = metric;
@@ -771,10 +772,10 @@ update_route_metric(struct babel_route *route)
     int old_smoothed_metric = route_smoothed_metric(route);
 
     if(route_expired(route)) {
-        if(route->refmetric < INFINITY) {
+        if(route->refmetric < BABEL_INFINITY) {
             route->seqno = seqno_plus(route->src->seqno, 1);
             retract_route(route);
-            if(oldmetric < INFINITY)
+            if(oldmetric < BABEL_INFINITY)
                 route_changed(route, route->src, oldmetric, route->price);
         }
     } else {
@@ -869,7 +870,7 @@ update_route(const unsigned char *id,
 
     add_metric = input_filter(id, prefix, plen, src_prefix, src_plen,
                               neigh->address, neigh->ifp->ifindex);
-    if(add_metric >= INFINITY)
+    if(add_metric >= BABEL_INFINITY)
         return NULL;
 
     route = find_route(prefix, plen, src_prefix, src_plen, neigh, nexthop);
@@ -884,7 +885,7 @@ update_route(const unsigned char *id,
         return NULL;
 
     feasible = update_feasible(src, seqno, refmetric);
-    metric = MIN((int)refmetric + neighbour_cost(neigh) + add_metric, INFINITY);
+    metric = MIN((int)refmetric + neighbour_cost(neigh) + add_metric, BABEL_INFINITY);
 
     if(route) {
         struct source *oldsrc;
@@ -915,7 +916,7 @@ update_route(const unsigned char *id,
         route->price = price + fee;
 
         route->src = retain_source(src);
-        if(refmetric < INFINITY)
+        if(refmetric < BABEL_INFINITY)
             route->time = now.tv_sec;
         route->seqno = seqno;
 
@@ -956,7 +957,7 @@ update_route(const unsigned char *id,
     } else {
         struct babel_route *new_route;
 
-        if(refmetric >= INFINITY)
+        if(refmetric >= BABEL_INFINITY)
             /* Somebody's retracting a route we never saw. */
             return NULL;
         if(!feasible) {
@@ -979,7 +980,7 @@ update_route(const unsigned char *id,
         memcpy(route->nexthop, nexthop, 16);
         route->time = now.tv_sec;
         route->hold_time = hold_time;
-        route->smoothed_metric = MAX(route_metric(route), INFINITY / 2);
+        route->smoothed_metric = MAX(route_metric(route), BABEL_INFINITY / 2);
         route->smoothed_metric_time = now.tv_sec;
         if(channels_len > 0) {
             route->channels = malloc(channels_len);
@@ -1022,7 +1023,7 @@ send_unfeasible_request(struct neighbour *neigh, int force,
     if(force || !route || route_metric(route) >= metric + 512) {
         send_unicast_multihop_request(neigh, src->prefix, src->plen,
                                       src->src_prefix, src->src_plen,
-                                      src->metric >= INFINITY ?
+                                      src->metric >= BABEL_INFINITY ?
                                       src->seqno :
                                       seqno_plus(src->seqno, 1),
                                       src->id, 127);
@@ -1039,7 +1040,7 @@ consider_route(struct babel_route *route)
 {
     struct babel_route *installed;
     struct xroute *xroute;
-    unsigned long route_sum_metric, installed_sum_metric;
+    double route_sum_metric, installed_sum_metric;
 
     if(route->installed)
         return;
@@ -1059,15 +1060,25 @@ consider_route(struct babel_route *route)
     if(installed == NULL)
         goto install;
 
-    if(route_metric(route) >= INFINITY)
+    if(route_metric(route) >= BABEL_INFINITY)
         return;
 
-    if(route_metric(installed) >= INFINITY)
+    if(route_metric(installed) >= BABEL_INFINITY)
         goto install;
 
 
-    installed_sum_metric = installed->price + route_smoothed_metric(installed) * quality_multiplier;
-    route_sum_metric = route->price + route_smoothed_metric(route) * quality_multiplier;
+    /**
+     * Quick overview of Althea price/quality decision-making:
+     *
+     * Formula:
+     * metric(price, interference, coefficient) = log2(price) + log2(interference) * coefficient
+     *
+     * The gist of the formula is that at coefficient equal to 1 we'll only
+     * install an x times pricier route if it offers *more than x* times lower
+     * interference. i.e. 
+     */
+    installed_sum_metric = log2((double)installed->price) + log2((double)route_smoothed_metric(installed)) * ((double)metric_factor / 1000.0);
+    route_sum_metric = log2((double)route->price) + log2((double)route_smoothed_metric(route)) * ((double)metric_factor / 1000.0);
     if(route_sum_metric < installed_sum_metric)
         goto install;
 
@@ -1092,10 +1103,10 @@ retract_neighbour_routes(struct neighbour *neigh)
         struct babel_route *r = routes[i];
         while(r) {
             if(r->neigh == neigh) {
-                if(r->refmetric != INFINITY) {
+                if(r->refmetric != BABEL_INFINITY) {
                     unsigned short oldmetric = route_metric(r);
                     retract_route(r);
-                    if(oldmetric != INFINITY)
+                    if(oldmetric != BABEL_INFINITY)
                         route_changed(r, r->src, oldmetric, r->price);
                 }
             }
@@ -1119,7 +1130,7 @@ send_triggered_update(struct babel_route *route, struct source *oldsrc,
     diff =
         newmetric >= oldmetric ? newmetric - oldmetric : oldmetric - newmetric;
 
-    if(route->src != oldsrc || (oldmetric < INFINITY && newmetric >= INFINITY))
+    if(route->src != oldsrc || (oldmetric < BABEL_INFINITY && newmetric >= BABEL_INFINITY))
         /* Switching sources can cause transient routing loops.
            Retractions can cause blackholes. */
         urgent = 2;
@@ -1131,7 +1142,7 @@ send_triggered_update(struct babel_route *route, struct source *oldsrc,
                                 route->seqno, route->src->id))
         /* Make sure that requests are satisfied speedily */
         urgent = 1;
-    else if(oldmetric >= INFINITY && newmetric < INFINITY)
+    else if(oldmetric >= BABEL_INFINITY && newmetric < BABEL_INFINITY)
         /* New route */
         urgent = 0;
     else if(newmetric < oldmetric && diff < 1024)
@@ -1151,7 +1162,7 @@ send_triggered_update(struct babel_route *route, struct source *oldsrc,
         send_update(NULL, urgent, route->src->prefix, route->src->plen,
                     route->src->src_prefix, route->src->src_plen);
 
-    if(oldmetric < INFINITY) {
+    if(oldmetric < BABEL_INFINITY) {
         if(newmetric >= oldmetric + 288) {
             send_request(NULL, route->src->prefix, route->src->plen,
                          route->src->src_prefix, route->src->src_plen);
@@ -1196,17 +1207,17 @@ route_lost(struct source *src, unsigned oldmetric)
                                 src->src_prefix, src->src_plen, 1, NULL);
     if(new_route) {
         consider_route(new_route);
-    } else if(oldmetric < INFINITY) {
+    } else if(oldmetric < BABEL_INFINITY) {
         /* Avoid creating a blackhole. */
         send_update_resend(NULL, src->prefix, src->plen,
                            src->src_prefix, src->src_plen);
         /* If the route was usable enough, try to get an alternate one.
            If it was not, we could be dealing with oscillations around
-           the value of INFINITY. */
-        if(oldmetric <= INFINITY / 2)
+           the value of BABEL_INFINITY. */
+        if(oldmetric <= BABEL_INFINITY / 2)
             send_request_resend(src->prefix, src->plen,
                                 src->src_prefix, src->src_plen,
-                                src->metric >= INFINITY ?
+                                src->metric >= BABEL_INFINITY ?
                                 src->seqno : seqno_plus(src->seqno, 1),
                                 src->id);
     }
@@ -1234,7 +1245,7 @@ expire_routes(void)
 
             update_route_metric(r);
 
-            if(r->installed && r->refmetric < INFINITY) {
+            if(r->installed && r->refmetric < BABEL_INFINITY) {
                 if(route_old(r))
                     /* Route about to expire, send a request. */
                     send_unicast_request(r->neigh,

--- a/route.h
+++ b/route.h
@@ -60,7 +60,7 @@ static inline int
 route_metric(const struct babel_route *route)
 {
     int m = (int)route->refmetric + route->cost + route->add_metric;
-    return MIN(m, INFINITY);
+    return MIN(m, BABEL_INFINITY);
 }
 
 static inline int
@@ -71,7 +71,7 @@ route_metric_noninterfering(const struct babel_route *route)
         (diversity_factor * route->cost + 128) / 256 +
         route->add_metric;
     m = MAX(m, route->refmetric + 1);
-    return MIN(m, INFINITY);
+    return MIN(m, BABEL_INFINITY);
 }
 
 struct babel_route *find_route(const unsigned char *prefix, unsigned char plen,

--- a/source.c
+++ b/source.c
@@ -149,7 +149,7 @@ find_source(const unsigned char *id,
     memcpy(src->src_prefix, src_prefix, 16);
     src->src_plen = src_plen;
     src->seqno = seqno;
-    src->metric = INFINITY;
+    src->metric = BABEL_INFINITY;
     src->time = now.tv_sec;
 
     if(source_slots >= max_source_slots)
@@ -186,7 +186,7 @@ void
 update_source(struct source *src,
               unsigned short seqno, unsigned short metric)
 {
-    if(metric >= INFINITY)
+    if(metric >= BABEL_INFINITY)
         return;
 
     /* If a source is expired, pretend that it doesn't exist and update

--- a/tests/multihop-smoketest.sh
+++ b/tests/multihop-smoketest.sh
@@ -109,22 +109,22 @@ EOF
 ip netns exec netlab-1 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-1 sysctl -w net.ipv6.conf.all.forwarding=1
 ip netns exec netlab-1 $BABELPATH -I babeld-n1.pid -d 1 -L babeld-n1.log -F 5 \
-  -w veth-1-4 -w veth-1-2 -h 1 -H 1 -C "default update-interval 1" -a 0 &
+  -w veth-1-4 -w veth-1-2 -h 1 -H 1 -C "default update-interval 1" -q 0 &
 
 ip netns exec netlab-2 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-2 sysctl -w net.ipv6.conf.all.forwarding=1
 ip netns exec netlab-2 $BABELPATH -I babeld-n2.pid -d 1 -L babeld-n2.log -F 10 \
-  -w veth-2-1 -w veth-2-3 -h 1 -H 1 -C "default update-interval 1" -a 0 &
+  -w veth-2-1 -w veth-2-3 -h 1 -H 1 -C "default update-interval 1" -q 0 &
 
 ip netns exec netlab-3 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-3 sysctl -w net.ipv6.conf.all.forwarding=1
 ip netns exec netlab-3 $BABELPATH -I babeld-n3.pid -d 1 -L babeld-n3.log -F 1 \
-  -w veth-3-2 -w veth-3-4 -h 1 -H 1 -C "default update-interval 1" -a 0 &
+  -w veth-3-2 -w veth-3-4 -h 1 -H 1 -C "default update-interval 1" -q 0 &
 
 ip netns exec netlab-4 sysctl -w net.ipv4.ip_forward=1
 ip netns exec netlab-4 sysctl -w net.ipv6.conf.all.forwarding=1
 ip netns exec netlab-4 $BABELPATH -I babeld-n4.pid -d 1 -L babeld-n4.log -F 7 \
-  -w veth-4-3 -w veth-4-1 -h 1 -H 1 -C "default update-interval 1" -a 0&
+  -w veth-4-3 -w veth-4-1 -h 1 -H 1 -C "default update-interval 1" -q 0&
 
 sleep $CONVERGENCE_DELAY_SEC
 
@@ -137,6 +137,11 @@ fail_string "unknown version" "babeld-n1.log"
 fail_string "unknown version" "babeld-n2.log"
 fail_string "unknown version" "babeld-n3.log"
 fail_string "unknown version" "babeld-n4.log"
+
+if [[ -v DEBUG ]]; then
+  echo "Debug mode is active, press Enter to finish the tests and exit"
+  read -n 1
+fi
 
 # ============================ PRICE TESTS =====================================
 

--- a/xroute.c
+++ b/xroute.c
@@ -307,7 +307,7 @@ check_xroutes(int send_updates)
                                      xroutes[i].src_prefix, xroutes[i].src_plen,
                                      xroutes[i].ifindex, xroutes[i].proto,
                                      NULL);
-        if(metric < INFINITY && metric == xroutes[i].metric) {
+        if(metric < BABEL_INFINITY && metric == xroutes[i].metric) {
             for(j = 0; j < numroutes; j++) {
                 if(xroutes[i].plen == routes[j].plen &&
                    memcmp(xroutes[i].prefix, routes[j].prefix, 16) == 0 &&
@@ -349,7 +349,7 @@ check_xroutes(int send_updates)
         metric = redistribute_filter(routes[i].prefix, routes[i].plen,
                                      routes[i].src_prefix, routes[i].src_plen,
                                      routes[i].ifindex, routes[i].proto, NULL);
-        if(metric < INFINITY) {
+        if(metric < BABEL_INFINITY) {
             rc = add_xroute(routes[i].prefix, routes[i].plen,
                             routes[i].src_prefix, routes[i].src_plen,
                             metric, routes[i].ifindex, routes[i].proto);


### PR DESCRIPTION
    Modify price/quality behavior
    
    This PR implements the log2()-based price/quality metric:
    
    metric(p, m, f) = log2(p) + log2(m) * f
    
    p: The price
    m: Babel's traditional quality-based metric value
    f: The metric factor - decides how much we value metric (quality)
    improvement vs. price improvement when comparing routes
    
    Makefile:
    * Link libm to get math.h to work
    
    babeld.c:
    * Change quality_multiplier to metric_factor, widen it to uint32_t and
    change the default to 1900 (1.9)
    * Change the metric factor's CLI option to 'q'
    
    babeld.h:
    disambiguation.c:
    local.c:
    message.c:
    neighbour.c:
    resend.c:
    route.h:
    source.c:
    xroute.c
    * INFINITY -> BABEL_INFINITY to resolve a conflict with math.h
    
    configuration.c:
    * INFINITY -> BABEL_INFINITY to resolve a conflict with math.h
    * Add metric-factor to the weird blacklist if in parse_option()
    
    route.c:
    * INFINITY -> BABEL_INFINITY to resolve a conflict with math.h
    * Implement the new metric formula
    
    tests/multihop-smoketest.sh:
    * Account for the metric factor option name change
    * Add a debug mode stop before test assertions too